### PR TITLE
Add support for non-async calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The APIs available are
  - Length()
  - Key()
 
- **All APIs are now _async_**
+ **All APIs in `ILocalStorageService` are _async_**
+
+If you are using Blazor (not Razor Components), you can choose to instead inject `Blazored.LocalStorage.ISyncStorageService` to opt into a synchronous API that allows you to avoid use of `async`/`await`.  For either interface, the method names are the same.
 
 **Note:** Blazored.LocalStorage methods will handle the serialisation and de-serialisation of the data for you.

--- a/samples/BlazorSample/Pages/Sync.cshtml
+++ b/samples/BlazorSample/Pages/Sync.cshtml
@@ -1,0 +1,94 @@
+﻿@page "/sync"
+@inject ISyncLocalStorageService localStorage
+
+<h1>Non Async Local Storage</h1>
+
+<div class="row mb-5">
+
+    <div class="col-md-4">
+        <h5>Add Item to local storage</h5>
+        <div class="input-group">
+            <input class="form-control" type="text" placeholder="Enter a value" bind="@Name" />
+            <div class="input-group-append">
+                <button class="btn btn-primary" onclick="@SaveName">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-4">
+        <h5>Remove item from local storage</h5>
+        <button class="btn btn-primary" onclick=@RemoveName>Remove Item</button>
+    </div>
+
+    <div class="col-md-4">
+        <h5>Clear local storage</h5>
+        <button class="btn btn-primary" onclick=@ClearLocalStorage>Clear All</button>
+    </div>
+</div>
+
+<div class="row">
+
+    <div class="col-md-4">
+        <h5>Value Read from local storage</h5>
+        @NameFromLocalStorage
+    </div>
+
+    <div class="col-md-4">
+        <h5>Items in local storage</h5>
+        @ItemsInLocalStorage
+    </div>
+</div>
+
+@functions {
+
+string NameFromLocalStorage { get; set; }
+int ItemsInLocalStorage { get; set; }
+string Name { get; set; }
+
+protected override async Task OnInitAsync()
+{
+    await GetNameFromLocalStorage();
+    await GetLocalStorageLength();
+}
+
+async Task SaveName()
+{
+    localStorage.SetItem("name", Name);
+    await GetNameFromLocalStorage();
+    await GetLocalStorageLength();
+
+    Name = "";
+}
+
+async Task GetNameFromLocalStorage()
+{
+    NameFromLocalStorage = localStorage.GetItem<string>("name");
+
+    if (string.IsNullOrEmpty(NameFromLocalStorage))
+        NameFromLocalStorage = "Nothing Saved";
+}
+
+async Task RemoveName()
+{
+    localStorage.RemoveItem("name");
+    await GetNameFromLocalStorage();
+    await GetLocalStorageLength();
+}
+
+async Task ClearLocalStorage()
+{
+    Console.WriteLine("Calling Clear...");
+    localStorage.Clear();
+    Console.WriteLine("Getting name from local storage...");
+    await GetNameFromLocalStorage();
+    Console.WriteLine("Calling Get Length...");
+    await GetLocalStorageLength();
+}
+
+async Task GetLocalStorageLength()
+{
+    Console.WriteLine(localStorage.Length());
+    ItemsInLocalStorage = localStorage.Length();
+}
+
+}

--- a/samples/BlazorSample/Shared/NavMenu.cshtml
+++ b/samples/BlazorSample/Shared/NavMenu.cshtml
@@ -11,6 +11,9 @@
             <NavLink class="nav-link" href="" Match=NavLinkMatch.All>
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
+            <NavLink class="nav-link" href="/sync">
+                <span class="oi oi-bolt" aria-hidden="true"></span> Non Async
+            </NavLink>
         </li>
     </ul>
 </div>

--- a/src/Blazored.LocalStorage/ISyncLocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ISyncLocalStorageService.cs
@@ -1,0 +1,17 @@
+﻿namespace Blazored.LocalStorage
+{
+    public interface ISyncLocalStorageService
+    {
+        void Clear();
+
+        T GetItem<T>(string key);
+
+        string Key(int index);
+
+        int Length();
+
+        void RemoveItem(string key);
+
+        void SetItem(string key, object data);
+    }
+}

--- a/src/Blazored.LocalStorage/ServiceCollectionExtensions.cs
+++ b/src/Blazored.LocalStorage/ServiceCollectionExtensions.cs
@@ -6,7 +6,9 @@ namespace Blazored.LocalStorage
     {
         public static IServiceCollection AddBlazoredLocalStorage(this IServiceCollection services)
         {
-            return services.AddScoped<ILocalStorageService, LocalStorageService>();
+            return services
+                .AddScoped<ILocalStorageService, LocalStorageService>()
+                .AddScoped<ISyncLocalStorageService, LocalStorageService>();
         }
     }
 }


### PR DESCRIPTION
Adds support for interacting with local storage without having to go through async calls when hosted in Blazor by allowing consumers to choose between the standard `ILocalStorageService` and a non-async `ISyncLocalStorageService`.