### PR TITLE
Tweak async/await implementation and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ public void ConfigureServices(IServiceCollection services)
 ``` 
 
 ### Usage
+
 This is an example of using local storage in a .cshtml file 
 
 ```c#
@@ -41,23 +42,44 @@ This is an example of using local storage in a .cshtml file
 
     protected override async Task OnInitAsync()
     {
-        await localStorage.SetItem("name", "John Smith");
-        var name = await localStorage.GetItem<string>("name");
+        await localStorage.SetItemAsync("name", "John Smith");
+        var name = await localStorage.GetItemAsync<string>("name");
     }
 
 }
 ```
 
-The APIs available are
- - SetItem()
- - GetItem()
- - RemoveItem()
- - Clear()
- - Length()
- - Key()
-
- **All APIs in `ILocalStorageService` are _async_**
-
 If you are using Blazor (not Razor Components), you can choose to instead inject `Blazored.LocalStorage.ISyncStorageService` to opt into a synchronous API that allows you to avoid use of `async`/`await`.  For either interface, the method names are the same.
+
+```c#
+@inject Blazored.LocalStorage.ISyncStorageService localStorage
+
+@functions {
+
+    protected override void OnInit()
+    {
+        localStorage.SetItem("name", "John Smith");
+        var name = localStorage.GetItem<string>("name");
+    }
+
+}
+```
+
+The APIs available are:
+
+- asynchronous via `ILocalStorageService`:
+  - SetItemAsync()
+  - GetItemAsync()
+  - RemoveItemAsync()
+  - ClearAsync()
+  - LengthAsync()
+  - KeyAsync()
+- synchronous via `ISyncStorageService`:
+  - SetItem()
+  - GetItem()
+  - RemoveItem()
+  - Clear()
+  - Length()
+  - Key()
 
 **Note:** Blazored.LocalStorage methods will handle the serialisation and de-serialisation of the data for you.

--- a/samples/BlazorSample/Pages/Index.cshtml
+++ b/samples/BlazorSample/Pages/Index.cshtml
@@ -64,7 +64,7 @@ Welcome to your new app.
 
     async Task SaveName()
     {
-        await localStorage.SetItem("name", Name);
+        await localStorage.SetItemAsync("name", Name);
         await GetNameFromLocalStorage();
         await GetLocalStorageLength();
 
@@ -73,7 +73,7 @@ Welcome to your new app.
 
     async Task GetNameFromLocalStorage()
     {
-        NameFromLocalStorage = await localStorage.GetItem<string>("name");
+        NameFromLocalStorage = await localStorage.GetItemAsync<string>("name");
 
         if (string.IsNullOrEmpty(NameFromLocalStorage))
             NameFromLocalStorage = "Nothing Saved";
@@ -81,7 +81,7 @@ Welcome to your new app.
 
     async Task RemoveName()
     {
-        await localStorage.RemoveItem("name");
+        await localStorage.RemoveItemAsync("name");
         await GetNameFromLocalStorage();
         await GetLocalStorageLength();
     }
@@ -89,7 +89,7 @@ Welcome to your new app.
     async Task ClearLocalStorage()
     {
         Console.WriteLine("Calling Clear...");
-        await localStorage.Clear();
+        await localStorage.ClearAsync();
         Console.WriteLine("Getting name from local storage...");
         await GetNameFromLocalStorage();
         Console.WriteLine("Calling Get Length...");
@@ -98,8 +98,8 @@ Welcome to your new app.
 
     async Task GetLocalStorageLength()
     {
-        Console.WriteLine(await localStorage.Length());
-        ItemsInLocalStorage = await localStorage.Length();
+        Console.WriteLine(await localStorage.LengthAsync());
+        ItemsInLocalStorage = await localStorage.LengthAsync();
     }
 
 }

--- a/samples/BlazorSample/Pages/Sync.cshtml
+++ b/samples/BlazorSample/Pages/Sync.cshtml
@@ -45,10 +45,10 @@
     int ItemsInLocalStorage { get; set; }
     string Name { get; set; }
 
-    protected override async Task OnInitAsync()
+    protected override void OnInit()
     {
-        await GetNameFromLocalStorage();
-        await GetLocalStorageLength();
+        GetNameFromLocalStorage();
+        GetLocalStorageLength();
 
         localStorage.Changed += (sender, e) =>
         {
@@ -56,16 +56,16 @@
         };
     }
 
-    async Task SaveName()
+    void SaveName()
     {
         localStorage.SetItem("name", Name);
-        await GetNameFromLocalStorage();
-        await GetLocalStorageLength();
+        GetNameFromLocalStorage();
+        GetLocalStorageLength();
 
         Name = "";
     }
 
-    async Task GetNameFromLocalStorage()
+    void GetNameFromLocalStorage()
     {
         NameFromLocalStorage = localStorage.GetItem<string>("name");
 
@@ -73,24 +73,24 @@
             NameFromLocalStorage = "Nothing Saved";
     }
 
-    async Task RemoveName()
+    void RemoveName()
     {
         localStorage.RemoveItem("name");
-        await GetNameFromLocalStorage();
-        await GetLocalStorageLength();
+        GetNameFromLocalStorage();
+        GetLocalStorageLength();
     }
 
-    async Task ClearLocalStorage()
+    void ClearLocalStorage()
     {
         Console.WriteLine("Calling Clear...");
         localStorage.Clear();
         Console.WriteLine("Getting name from local storage...");
-        await GetNameFromLocalStorage();
+        GetNameFromLocalStorage();
         Console.WriteLine("Calling Get Length...");
-        await GetLocalStorageLength();
+        GetLocalStorageLength();
     }
 
-    async Task GetLocalStorageLength()
+    void GetLocalStorageLength()
     {
         Console.WriteLine(localStorage.Length());
         ItemsInLocalStorage = localStorage.Length();

--- a/src/Blazored.LocalStorage/ILocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ILocalStorageService.cs
@@ -5,17 +5,17 @@ namespace Blazored.LocalStorage
 {
     public interface ILocalStorageService
     {
-        Task Clear();
+        Task ClearAsync();
 
-        Task<T> GetItem<T>(string key);
+        Task<T> GetItemAsync<T>(string key);
 
-        Task<string> Key(int index);
+        Task<string> KeyAsync(int index);
 
-        Task<int> Length();
+        Task<int> LengthAsync();
 
-        Task RemoveItem(string key);
+        Task RemoveItemAsync(string key);
 
-        Task SetItem(string key, object data);
+        Task SetItemAsync(string key, object data);
 
         event EventHandler<ChangingEventArgs> Changing;
         event EventHandler<ChangedEventArgs> Changed;

--- a/src/Blazored.LocalStorage/LocalStorageService.cs
+++ b/src/Blazored.LocalStorage/LocalStorageService.cs
@@ -15,7 +15,7 @@ namespace Blazored.LocalStorage
             _jSInProcessRuntime = jSRuntime as IJSInProcessRuntime;
         }
 
-        public async Task SetItem(string key, object data)
+        public async Task SetItemAsync(string key, object data)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
@@ -30,7 +30,7 @@ namespace Blazored.LocalStorage
             RaiseOnChanged(key, e.OldValue, data);
         }
 
-        public async Task<T> GetItem<T>(string key)
+        public async Task<T> GetItemAsync<T>(string key)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
@@ -43,19 +43,19 @@ namespace Blazored.LocalStorage
             return Json.Deserialize<T>(serialisedData);
         }
 
-        public Task RemoveItem(string key)
+        public async Task RemoveItemAsync(string key)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
-            return _jSRuntime.InvokeAsync<object>("Blazored.LocalStorage.RemoveItem", key);
+            await _jSRuntime.InvokeAsync<object>("Blazored.LocalStorage.RemoveItem", key);
         }
 
-        public Task Clear() => _jSRuntime.InvokeAsync<object>("Blazored.LocalStorage.Clear");
+        public async Task ClearAsync() => await _jSRuntime.InvokeAsync<object>("Blazored.LocalStorage.Clear");
 
-        public Task<int> Length() => _jSRuntime.InvokeAsync<int>("Blazored.LocalStorage.Length");
+        public async Task<int> LengthAsync() => await _jSRuntime.InvokeAsync<int>("Blazored.LocalStorage.Length");
 
-        public Task<string> Key(int index) => _jSRuntime.InvokeAsync<string>("Blazored.LocalStorage.Key", index);
+        public async Task<string> KeyAsync(int index) => await _jSRuntime.InvokeAsync<string>("Blazored.LocalStorage.Key", index);
 
         void ISyncLocalStorageService.SetItem(string key, object data)
         {
@@ -129,7 +129,7 @@ namespace Blazored.LocalStorage
             var e = new ChangingEventArgs
             {
                 Key = key,
-                OldValue = await GetItem<object>(key),
+                OldValue = await GetItemAsync<object>(key),
                 NewValue = data
             };
 


### PR DESCRIPTION
I understand this could break things, but at the same time I think it would be better to stick to established naming conventions for async/awaits implementation (the point of using Blazor is to let C# developers feel at home).
This commit
- sticks to MS convention for `async Task/Task<T> {NAME}Async` naming
- updates `ILocalStorageService` definition
- updates `LocalStorageService` implementation
- updates usage on dedicated client pages
- updates README

After this change it's obvious which method are expected to be used within async methods and which are not, removing a little confusion (IMO) found e.g. on the sync page with all those async/awaits being used there.

Thanks!