### PR TITLE
Possible fix for the missing js file

### DIFF
--- a/src/Blazored.LocalStorage/Blazored.LocalStorage.csproj
+++ b/src/Blazored.LocalStorage/Blazored.LocalStorage.csproj
@@ -26,8 +26,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- 
+        Explicitly name thie js file because it won't exist when the build target that needs it runs...
+    -->
+    <EmbeddedResource Include="wwwroot\blazored-localstorage.js" LogicalName="blazor:js:%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- 
+        Don't use the wildcard globbing because you will get duplicate resource errors 
+        - as the js file does exist when the csproj is validated 
+    -->
     <!-- .js/.css files will be referenced via <script>/<link> tags; other content files will just be included in the app's 'dist' directory without any tags referencing them -->
-    <EmbeddedResource Include="wwwroot\**\*.js" LogicalName="blazor:js:%(RecursiveDir)%(Filename)%(Extension)" />
     <EmbeddedResource Include="wwwroot\**\*.css" LogicalName="blazor:css:%(RecursiveDir)%(Filename)%(Extension)" />
     <EmbeddedResource Include="wwwroot\**" Exclude="**\*.js;**\*.css" LogicalName="blazor:file:%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>


### PR DESCRIPTION
When the build runs, one of the key targets is run before the Typescript compilation, so the .js file is not there.
Explicitly naming the js file in the csproj allows the build to include it before it has been created.