### PR TITLE
non-generic local storage access

### DIFF
--- a/src/Blazored.LocalStorage/ILocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ILocalStorageService.cs
@@ -8,6 +8,7 @@ namespace Blazored.LocalStorage
         Task ClearAsync();
 
         Task<T> GetItemAsync<T>(string key);
+        Task<object> GetItemAsync(string key, Type type);
 
         Task<string> KeyAsync(int index);
 

--- a/src/Blazored.LocalStorage/ISyncLocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ISyncLocalStorageService.cs
@@ -8,6 +8,8 @@ namespace Blazored.LocalStorage
 
         T GetItem<T>(string key);
 
+        object GetItem(string key, Type type);
+
         string Key(int index);
 
         /// <summary>


### PR DESCRIPTION
Intention: Use local storage in combination with Fluxor to create auto-state recovery for features:

Middleware:

    using Blazor.Fluxor;
    using Blazored.LocalStorage;
    
    namespace RonSijm
    {
        public class RestoreStateMiddleware : Middleware
        {
            private readonly ISyncLocalStorageService _syncLocalStorageService;
    
            public RestoreStateMiddleware(ISyncLocalStorageService syncLocalStorageService)
            {
                _syncLocalStorageService = syncLocalStorageService;
            }
    
            public override void AfterInitializeAllMiddlewares()
            {
                foreach (var storeFeature in Store.Features)
                {
                    var name = storeFeature.Value.GetName();
                    var type = storeFeature.Value.GetStateType();
                    var item = _syncLocalStorageService.GetItem(name, type);
    
                    if (item == null)
                    {
                        continue;
                    }
    
                    storeFeature.Value.RestoreState(item);
                }
    
                base.AfterInitializeAllMiddlewares();
            }
        }
    }