### PR TITLE
Get string without deserialization

### DIFF
--- a/samples/BlazorClientSide/Pages/Index.razor
+++ b/samples/BlazorClientSide/Pages/Index.razor
@@ -7,134 +7,134 @@
 
 <div class="row mb-5">
 
-	<div class="col-md-4">
-		<h5>Add Item to local storage</h5>
-		<div class="input-group">
-			<input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
-			<div class="input-group-append">
-				<button class="btn btn-primary" @onclick="SaveName">Save</button>
-			</div>
-		</div>
-	</div>
+    <div class="col-md-4">
+        <h5>Add Item to local storage</h5>
+        <div class="input-group">
+            <input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
+            <div class="input-group-append">
+                <button class="btn btn-primary" @onclick="SaveName">Save</button>
+            </div>
+        </div>
+    </div>
 
-	<div class="col-md-4">
-		<h5>Remove item from local storage</h5>
-		<button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
-	</div>
+    <div class="col-md-4">
+        <h5>Remove item from local storage</h5>
+        <button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
+    </div>
 
-	<div class="col-md-4">
-		<h5>Clear local storage</h5>
-		<button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
-	</div>
+    <div class="col-md-4">
+        <h5>Clear local storage</h5>
+        <button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
+    </div>
 </div>
 
 <div class="row mb-5">
 
-	<div class="col-md-4">
-		<h5>Value Read from local storage</h5>
-		@NameFromLocalStorage
-	</div>
+    <div class="col-md-4">
+        <h5>Value Read from local storage</h5>
+        @NameFromLocalStorage
+    </div>
 
-	<div class="col-md-4">
-		<h5>Items in local storage</h5>
-		@ItemsInLocalStorage
-	</div>
+    <div class="col-md-4">
+        <h5>Items in local storage</h5>
+        @ItemsInLocalStorage
+    </div>
 
-	<div class="col-md-4">
-		<h5>Item exist in local storage</h5>@(ItemExist)
-	</div>
+    <div class="col-md-4">
+        <h5>Item exist in local storage</h5>@(ItemExist)
+    </div>
 </div>
 
 <div class="row">
 
-	<div class="col-md-4">
-		<h5>String Read from local storage</h5>
-		@StringFromLocalStorage
-	</div>
+    <div class="col-md-4">
+        <h5>String Read from local storage</h5>
+        @StringFromLocalStorage
+    </div>
 </div>
 
 @code {
 
-	string NameFromLocalStorage { get; set; }
-	string StringFromLocalStorage { get; set; }
-	int ItemsInLocalStorage { get; set; }
-	string Name { get; set; }
-	bool ItemExist { get; set; }
+    string NameFromLocalStorage { get; set; }
+    string StringFromLocalStorage { get; set; }
+    int ItemsInLocalStorage { get; set; }
+    string Name { get; set; }
+    bool ItemExist { get; set; }
 
-	protected override async Task OnInitializedAsync()
-	{
-		await GetNameFromLocalStorage();
-		await GetStringFromLocalStorage();
-		await GetLocalStorageLength();
+    protected override async Task OnInitializedAsync()
+    {
+        await GetNameFromLocalStorage();
+        await GetStringFromLocalStorage();
+        await GetLocalStorageLength();
 
-		localStorage.Changed += (sender, e) =>
-		{
-			Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
-		};
-	}
+        localStorage.Changed += (sender, e) =>
+        {
+            Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
+        };
+    }
 
-	async Task SaveName()
-	{
-		await localStorage.SetItemAsync("name", Name);
-		await GetNameFromLocalStorage();
-		await GetStringFromLocalStorage();
-		await GetLocalStorageLength();
+    async Task SaveName()
+    {
+        await localStorage.SetItemAsync("name", Name);
+        await GetNameFromLocalStorage();
+        await GetStringFromLocalStorage();
+        await GetLocalStorageLength();
 
-		Name = "";
-	}
+        Name = "";
+    }
 
-	async Task GetNameFromLocalStorage()
-	{
-		try
-		{
-			NameFromLocalStorage = await localStorage.GetItemAsync<string>("name");
+    async Task GetNameFromLocalStorage()
+    {
+        try
+        {
+            NameFromLocalStorage = await localStorage.GetItemAsync<string>("name");
 
-			if (string.IsNullOrEmpty(NameFromLocalStorage))
-			{
-				NameFromLocalStorage = "Nothing Saved";
-			}
-		}
-		catch(Exception)
-		{
-			Console.WriteLine("error reading 'name'");
-		}
-	}
+            if (string.IsNullOrEmpty(NameFromLocalStorage))
+            {
+                NameFromLocalStorage = "Nothing Saved";
+            }
+        }
+        catch(Exception)
+        {
+            Console.WriteLine("error reading 'name'");
+        }
+    }
 
 
-	async Task GetStringFromLocalStorage()
-	{
-		StringFromLocalStorage = await localStorage.GetStringAsync("name");
+    async Task GetStringFromLocalStorage()
+    {
+        StringFromLocalStorage = await localStorage.GetStringAsync("name");
 
-		if (string.IsNullOrEmpty(StringFromLocalStorage))
-		{
-			StringFromLocalStorage = "Nothing Saved";
-		}
-	}
+        if (string.IsNullOrEmpty(StringFromLocalStorage))
+        {
+            StringFromLocalStorage = "Nothing Saved";
+        }
+    }
 
-	async Task RemoveName()
-	{
-		await localStorage.RemoveItemAsync("name");
-		await GetNameFromLocalStorage();
-		await GetStringFromLocalStorage();
-		await GetLocalStorageLength();
-	}
+    async Task RemoveName()
+    {
+        await localStorage.RemoveItemAsync("name");
+        await GetNameFromLocalStorage();
+        await GetStringFromLocalStorage();
+        await GetLocalStorageLength();
+    }
 
-	async Task ClearLocalStorage()
-	{
-		Console.WriteLine("Calling Clear...");
-		await localStorage.ClearAsync();
-		Console.WriteLine("Getting name from local storage...");
-		await GetNameFromLocalStorage();
-		await GetStringFromLocalStorage();
-		Console.WriteLine("Calling Get Length...");
-		await GetLocalStorageLength();
-	}
+    async Task ClearLocalStorage()
+    {
+        Console.WriteLine("Calling Clear...");
+        await localStorage.ClearAsync();
+        Console.WriteLine("Getting name from local storage...");
+        await GetNameFromLocalStorage();
+        await GetStringFromLocalStorage();
+        Console.WriteLine("Calling Get Length...");
+        await GetLocalStorageLength();
+    }
 
-	async Task GetLocalStorageLength()
-	{
-		Console.WriteLine(await localStorage.LengthAsync());
-		ItemsInLocalStorage = await localStorage.LengthAsync();
-		ItemExist = await localStorage.ContainKeyAsync("name");
-	}
+    async Task GetLocalStorageLength()
+    {
+        Console.WriteLine(await localStorage.LengthAsync());
+        ItemsInLocalStorage = await localStorage.LengthAsync();
+        ItemExist = await localStorage.ContainKeyAsync("name");
+    }
 
 }

--- a/samples/BlazorClientSide/Pages/Index.razor
+++ b/samples/BlazorClientSide/Pages/Index.razor
@@ -7,103 +7,134 @@
 
 <div class="row mb-5">
 
-    <div class="col-md-4">
-        <h5>Add Item to local storage</h5>
-        <div class="input-group">
-            <input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
-            <div class="input-group-append">
-                <button class="btn btn-primary" @onclick="SaveName">Save</button>
-            </div>
-        </div>
-    </div>
+	<div class="col-md-4">
+		<h5>Add Item to local storage</h5>
+		<div class="input-group">
+			<input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
+			<div class="input-group-append">
+				<button class="btn btn-primary" @onclick="SaveName">Save</button>
+			</div>
+		</div>
+	</div>
 
-    <div class="col-md-4">
-        <h5>Remove item from local storage</h5>
-        <button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
-    </div>
+	<div class="col-md-4">
+		<h5>Remove item from local storage</h5>
+		<button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
+	</div>
 
-    <div class="col-md-4">
-        <h5>Clear local storage</h5>
-        <button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
-    </div>
+	<div class="col-md-4">
+		<h5>Clear local storage</h5>
+		<button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
+	</div>
+</div>
+
+<div class="row mb-5">
+
+	<div class="col-md-4">
+		<h5>Value Read from local storage</h5>
+		@NameFromLocalStorage
+	</div>
+
+	<div class="col-md-4">
+		<h5>Items in local storage</h5>
+		@ItemsInLocalStorage
+	</div>
+
+	<div class="col-md-4">
+		<h5>Item exist in local storage</h5>@(ItemExist)
+	</div>
 </div>
 
 <div class="row">
 
-    <div class="col-md-4">
-        <h5>Value Read from local storage</h5>
-        @NameFromLocalStorage
-    </div>
-
-    <div class="col-md-4">
-        <h5>Items in local storage</h5>
-        @ItemsInLocalStorage
-    </div>
-
-    <div class="col-md-4">
-        <h5>Item exist in local storage</h5>@(ItemExist)
-    </div>
+	<div class="col-md-4">
+		<h5>String Read from local storage</h5>
+		@StringFromLocalStorage
+	</div>
 </div>
 
 @code {
 
-    string NameFromLocalStorage { get; set; }
-    int ItemsInLocalStorage { get; set; }
-    string Name { get; set; }
-    bool ItemExist { get; set; }
+	string NameFromLocalStorage { get; set; }
+	string StringFromLocalStorage { get; set; }
+	int ItemsInLocalStorage { get; set; }
+	string Name { get; set; }
+	bool ItemExist { get; set; }
 
-    protected override async Task OnInitializedAsync()
-    {
-        await GetNameFromLocalStorage();
-        await GetLocalStorageLength();
+	protected override async Task OnInitializedAsync()
+	{
+		await GetNameFromLocalStorage();
+		await GetStringFromLocalStorage();
+		await GetLocalStorageLength();
 
-        localStorage.Changed += (sender, e) =>
-        {
-            Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
-        };
-    }
+		localStorage.Changed += (sender, e) =>
+		{
+			Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
+		};
+	}
 
-    async Task SaveName()
-    {
-        await localStorage.SetItemAsync("name", Name);
-        await GetNameFromLocalStorage();
-        await GetLocalStorageLength();
+	async Task SaveName()
+	{
+		await localStorage.SetItemAsync("name", Name);
+		await GetNameFromLocalStorage();
+		await GetStringFromLocalStorage();
+		await GetLocalStorageLength();
 
-        Name = "";
-    }
+		Name = "";
+	}
 
-    async Task GetNameFromLocalStorage()
-    {
-        NameFromLocalStorage = await localStorage.GetItemAsync<string>("name");
+	async Task GetNameFromLocalStorage()
+	{
+		try
+		{
+			NameFromLocalStorage = await localStorage.GetItemAsync<string>("name");
 
-        if (string.IsNullOrEmpty(NameFromLocalStorage))
-        {
-            NameFromLocalStorage = "Nothing Saved";
-        }
-    }
+			if (string.IsNullOrEmpty(NameFromLocalStorage))
+			{
+				NameFromLocalStorage = "Nothing Saved";
+			}
+		}
+		catch(Exception)
+		{
+			Console.WriteLine("error reading 'name'");
+		}
+	}
 
-    async Task RemoveName()
-    {
-        await localStorage.RemoveItemAsync("name");
-        await GetNameFromLocalStorage();
-        await GetLocalStorageLength();
-    }
 
-    async Task ClearLocalStorage()
-    {
-        Console.WriteLine("Calling Clear...");
-        await localStorage.ClearAsync();
-        Console.WriteLine("Getting name from local storage...");
-        await GetNameFromLocalStorage();
-        Console.WriteLine("Calling Get Length...");
-        await GetLocalStorageLength();
-    }
+	async Task GetStringFromLocalStorage()
+	{
+		StringFromLocalStorage = await localStorage.GetStringAsync("name");
 
-    async Task GetLocalStorageLength()
-    {
-        Console.WriteLine(await localStorage.LengthAsync());
-        ItemsInLocalStorage = await localStorage.LengthAsync();
-        ItemExist = await localStorage.ContainKeyAsync("name");
-    }
+		if (string.IsNullOrEmpty(StringFromLocalStorage))
+		{
+			StringFromLocalStorage = "Nothing Saved";
+		}
+	}
+
+	async Task RemoveName()
+	{
+		await localStorage.RemoveItemAsync("name");
+		await GetNameFromLocalStorage();
+		await GetStringFromLocalStorage();
+		await GetLocalStorageLength();
+	}
+
+	async Task ClearLocalStorage()
+	{
+		Console.WriteLine("Calling Clear...");
+		await localStorage.ClearAsync();
+		Console.WriteLine("Getting name from local storage...");
+		await GetNameFromLocalStorage();
+		await GetStringFromLocalStorage();
+		Console.WriteLine("Calling Get Length...");
+		await GetLocalStorageLength();
+	}
+
+	async Task GetLocalStorageLength()
+	{
+		Console.WriteLine(await localStorage.LengthAsync());
+		ItemsInLocalStorage = await localStorage.LengthAsync();
+		ItemExist = await localStorage.ContainKeyAsync("name");
+	}
 
 }

--- a/samples/BlazorClientSide/Pages/Sync.razor
+++ b/samples/BlazorClientSide/Pages/Sync.razor
@@ -5,133 +5,133 @@
 
 <div class="row mb-5">
 
-	<div class="col-md-4">
-		<h5>Add Item to local storage</h5>
-		<div class="input-group">
-			<input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
-			<div class="input-group-append">
-				<button class="btn btn-primary" @onclick="SaveName">Save</button>
-			</div>
-		</div>
-	</div>
+    <div class="col-md-4">
+        <h5>Add Item to local storage</h5>
+        <div class="input-group">
+            <input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
+            <div class="input-group-append">
+                <button class="btn btn-primary" @onclick="SaveName">Save</button>
+            </div>
+        </div>
+    </div>
 
-	<div class="col-md-4">
-		<h5>Remove item from local storage</h5>
-		<button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
-	</div>
+    <div class="col-md-4">
+        <h5>Remove item from local storage</h5>
+        <button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
+    </div>
 
-	<div class="col-md-4">
-		<h5>Clear local storage</h5>
-		<button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
-	</div>
+    <div class="col-md-4">
+        <h5>Clear local storage</h5>
+        <button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
+    </div>
 </div>
 
 <div class="row">
 
-	<div class="col-md-4">
-		<h5>Value Read from local storage</h5>
-		@NameFromLocalStorage
-	</div>
+    <div class="col-md-4">
+        <h5>Value Read from local storage</h5>
+        @NameFromLocalStorage
+    </div>
 
-	<div class="col-md-4">
-		<h5>Items in local storage</h5>
-		@ItemsInLocalStorage
-	</div>
-	<div class="col-md-4">
-		<h5>Item exist in local storage</h5>@(ItemExist)
-	</div>
+    <div class="col-md-4">
+        <h5>Items in local storage</h5>
+        @ItemsInLocalStorage
+    </div>
+    <div class="col-md-4">
+        <h5>Item exist in local storage</h5>@(ItemExist)
+    </div>
 </div>
 
 <div class="row">
 
-	<div class="col-md-4">
-		<h5>String Read from local storage</h5>
-		@StringFromLocalStorage
-	</div>
+    <div class="col-md-4">
+        <h5>String Read from local storage</h5>
+        @StringFromLocalStorage
+    </div>
 </div>
 
 @code {
 
-	string NameFromLocalStorage { get; set; }
-	string StringFromLocalStorage { get; set; }
-	int ItemsInLocalStorage { get; set; }
-	string Name { get; set; }
-	bool ItemExist { get; set; }
+    string NameFromLocalStorage { get; set; }
+    string StringFromLocalStorage { get; set; }
+    int ItemsInLocalStorage { get; set; }
+    string Name { get; set; }
+    bool ItemExist { get; set; }
 
-	protected override void OnInitialized()
-	{
-		GetNameFromLocalStorage();
-		GetStringFromLocalStorage();
-		GetLocalStorageLength();
+    protected override void OnInitialized()
+    {
+        GetNameFromLocalStorage();
+        GetStringFromLocalStorage();
+        GetLocalStorageLength();
 
-		localStorage.Changed += (sender, e) =>
-		{
-			Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
-		};
-	}
+        localStorage.Changed += (sender, e) =>
+        {
+            Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
+        };
+    }
 
-	void SaveName()
-	{
-		Console.WriteLine(Name);
-		localStorage.SetItem("name", Name);
-		GetNameFromLocalStorage();
-		GetStringFromLocalStorage();
-		GetLocalStorageLength();
+    void SaveName()
+    {
+        Console.WriteLine(Name);
+        localStorage.SetItem("name", Name);
+        GetNameFromLocalStorage();
+        GetStringFromLocalStorage();
+        GetLocalStorageLength();
 
-		Name = "";
-	}
+        Name = "";
+    }
 
-	void GetNameFromLocalStorage()
-	{
-		try
-		{
-			NameFromLocalStorage = localStorage.GetItem<string>("name");
+    void GetNameFromLocalStorage()
+    {
+        try
+        {
+            NameFromLocalStorage = localStorage.GetItem<string>("name");
 
-			if (string.IsNullOrEmpty(NameFromLocalStorage))
-			{
-				NameFromLocalStorage = "Nothing Saved";
-			}
-		}
-		catch (Exception)
-		{
-			Console.WriteLine("error reading 'name'");
-		}
-	}
+            if (string.IsNullOrEmpty(NameFromLocalStorage))
+            {
+                NameFromLocalStorage = "Nothing Saved";
+            }
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("error reading 'name'");
+        }
+    }
 
-	void GetStringFromLocalStorage()
-	{
-		StringFromLocalStorage = localStorage.GetString("name");
+    void GetStringFromLocalStorage()
+    {
+        StringFromLocalStorage = localStorage.GetString("name");
 
-		if (string.IsNullOrEmpty(StringFromLocalStorage))
-		{
-			StringFromLocalStorage = "Nothing Saved";
-		}
-	}
+        if (string.IsNullOrEmpty(StringFromLocalStorage))
+        {
+            StringFromLocalStorage = "Nothing Saved";
+        }
+    }
 
-	void RemoveName()
-	{
-		localStorage.RemoveItem("name");
-		GetNameFromLocalStorage();
-		GetStringFromLocalStorage();
-		GetLocalStorageLength();
-	}
+    void RemoveName()
+    {
+        localStorage.RemoveItem("name");
+        GetNameFromLocalStorage();
+        GetStringFromLocalStorage();
+        GetLocalStorageLength();
+    }
 
-	void ClearLocalStorage()
-	{
-		Console.WriteLine("Calling Clear...");
-		localStorage.Clear();
-		Console.WriteLine("Getting name from local storage...");
-		GetNameFromLocalStorage();
-		GetStringFromLocalStorage();
-		Console.WriteLine("Calling Get Length...");
-		GetLocalStorageLength();
-	}
+    void ClearLocalStorage()
+    {
+        Console.WriteLine("Calling Clear...");
+        localStorage.Clear();
+        Console.WriteLine("Getting name from local storage...");
+        GetNameFromLocalStorage();
+        GetStringFromLocalStorage();
+        Console.WriteLine("Calling Get Length...");
+        GetLocalStorageLength();
+    }
 
-	void GetLocalStorageLength()
-	{
-		Console.WriteLine(localStorage.Length());
-		ItemsInLocalStorage = localStorage.Length();
-		ItemExist = localStorage.ContainKey("name");
-	}
+    void GetLocalStorageLength()
+    {
+        Console.WriteLine(localStorage.Length());
+        ItemsInLocalStorage = localStorage.Length();
+        ItemExist = localStorage.ContainKey("name");
+    }
 
 }

--- a/samples/BlazorClientSide/Pages/Sync.razor
+++ b/samples/BlazorClientSide/Pages/Sync.razor
@@ -5,103 +5,133 @@
 
 <div class="row mb-5">
 
-    <div class="col-md-4">
-        <h5>Add Item to local storage</h5>
-        <div class="input-group">
-            <input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
-            <div class="input-group-append">
-                <button class="btn btn-primary" @onclick="SaveName">Save</button>
-            </div>
-        </div>
-    </div>
+	<div class="col-md-4">
+		<h5>Add Item to local storage</h5>
+		<div class="input-group">
+			<input class="form-control" type="text" placeholder="Enter a value" @bind="Name" />
+			<div class="input-group-append">
+				<button class="btn btn-primary" @onclick="SaveName">Save</button>
+			</div>
+		</div>
+	</div>
 
-    <div class="col-md-4">
-        <h5>Remove item from local storage</h5>
-        <button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
-    </div>
+	<div class="col-md-4">
+		<h5>Remove item from local storage</h5>
+		<button class="btn btn-primary" @onclick="RemoveName">Remove Item</button>
+	</div>
 
-    <div class="col-md-4">
-        <h5>Clear local storage</h5>
-        <button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
-    </div>
+	<div class="col-md-4">
+		<h5>Clear local storage</h5>
+		<button class="btn btn-primary" @onclick="ClearLocalStorage">Clear All</button>
+	</div>
 </div>
 
 <div class="row">
 
-    <div class="col-md-4">
-        <h5>Value Read from local storage</h5>
-        @NameFromLocalStorage
-    </div>
+	<div class="col-md-4">
+		<h5>Value Read from local storage</h5>
+		@NameFromLocalStorage
+	</div>
 
-    <div class="col-md-4">
-        <h5>Items in local storage</h5>
-        @ItemsInLocalStorage
-    </div>
-    <div class="col-md-4">
-        <h5>Item exist in local storage</h5>@(ItemExist)
-    </div>
+	<div class="col-md-4">
+		<h5>Items in local storage</h5>
+		@ItemsInLocalStorage
+	</div>
+	<div class="col-md-4">
+		<h5>Item exist in local storage</h5>@(ItemExist)
+	</div>
+</div>
+
+<div class="row">
+
+	<div class="col-md-4">
+		<h5>String Read from local storage</h5>
+		@StringFromLocalStorage
+	</div>
 </div>
 
 @code {
 
-    string NameFromLocalStorage { get; set; }
-    int ItemsInLocalStorage { get; set; }
-    string Name { get; set; }
-    bool ItemExist { get; set; }
+	string NameFromLocalStorage { get; set; }
+	string StringFromLocalStorage { get; set; }
+	int ItemsInLocalStorage { get; set; }
+	string Name { get; set; }
+	bool ItemExist { get; set; }
 
-    protected override void OnInitialized()
-    {
-        GetNameFromLocalStorage();
-        GetLocalStorageLength();
+	protected override void OnInitialized()
+	{
+		GetNameFromLocalStorage();
+		GetStringFromLocalStorage();
+		GetLocalStorageLength();
 
-        localStorage.Changed += (sender, e) =>
-        {
-            Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
-        };
-    }
+		localStorage.Changed += (sender, e) =>
+		{
+			Console.WriteLine($"Value for key {e.Key} changed from {e.OldValue} to {e.NewValue}");
+		};
+	}
 
-    void SaveName()
-    {
-        Console.WriteLine(Name);
-        localStorage.SetItem("name", Name);
-        GetNameFromLocalStorage();
-        GetLocalStorageLength();
+	void SaveName()
+	{
+		Console.WriteLine(Name);
+		localStorage.SetItem("name", Name);
+		GetNameFromLocalStorage();
+		GetStringFromLocalStorage();
+		GetLocalStorageLength();
 
-        Name = "";
-    }
+		Name = "";
+	}
 
-    void GetNameFromLocalStorage()
-    {
-        NameFromLocalStorage = localStorage.GetItem<string>("name");
+	void GetNameFromLocalStorage()
+	{
+		try
+		{
+			NameFromLocalStorage = localStorage.GetItem<string>("name");
 
-        if (string.IsNullOrEmpty(NameFromLocalStorage))
-        {
-            NameFromLocalStorage = "Nothing Saved";
-        }
-    }
+			if (string.IsNullOrEmpty(NameFromLocalStorage))
+			{
+				NameFromLocalStorage = "Nothing Saved";
+			}
+		}
+		catch (Exception)
+		{
+			Console.WriteLine("error reading 'name'");
+		}
+	}
 
-    void RemoveName()
-    {
-        localStorage.RemoveItem("name");
-        GetNameFromLocalStorage();
-        GetLocalStorageLength();
-    }
+	void GetStringFromLocalStorage()
+	{
+		StringFromLocalStorage = localStorage.GetString("name");
 
-    void ClearLocalStorage()
-    {
-        Console.WriteLine("Calling Clear...");
-        localStorage.Clear();
-        Console.WriteLine("Getting name from local storage...");
-        GetNameFromLocalStorage();
-        Console.WriteLine("Calling Get Length...");
-        GetLocalStorageLength();
-    }
+		if (string.IsNullOrEmpty(StringFromLocalStorage))
+		{
+			StringFromLocalStorage = "Nothing Saved";
+		}
+	}
 
-    void GetLocalStorageLength()
-    {
-        Console.WriteLine(localStorage.Length());
-        ItemsInLocalStorage = localStorage.Length();
-        ItemExist = localStorage.ContainKey("name");
-    }
+	void RemoveName()
+	{
+		localStorage.RemoveItem("name");
+		GetNameFromLocalStorage();
+		GetStringFromLocalStorage();
+		GetLocalStorageLength();
+	}
+
+	void ClearLocalStorage()
+	{
+		Console.WriteLine("Calling Clear...");
+		localStorage.Clear();
+		Console.WriteLine("Getting name from local storage...");
+		GetNameFromLocalStorage();
+		GetStringFromLocalStorage();
+		Console.WriteLine("Calling Get Length...");
+		GetLocalStorageLength();
+	}
+
+	void GetLocalStorageLength()
+	{
+		Console.WriteLine(localStorage.Length());
+		ItemsInLocalStorage = localStorage.Length();
+		ItemExist = localStorage.ContainKey("name");
+	}
 
 }

--- a/src/Blazored.LocalStorage/ILocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ILocalStorageService.cs
@@ -9,6 +9,8 @@ namespace Blazored.LocalStorage
 
         Task<T> GetItemAsync<T>(string key);
 
+        Task<String> GetStringAsync(string key);
+
         Task<string> KeyAsync(int index);
 
         /// <summary>

--- a/src/Blazored.LocalStorage/ISyncLocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ISyncLocalStorageService.cs
@@ -7,6 +7,8 @@ namespace Blazored.LocalStorage
         void Clear();
 
         T GetItem<T>(string key);
+        
+        string GetString(string key);
 
         string Key(int index);
 

--- a/src/Blazored.LocalStorage/LocalStorageService.cs
+++ b/src/Blazored.LocalStorage/LocalStorageService.cs
@@ -138,7 +138,8 @@ namespace Blazored.LocalStorage
                 return (T)(object)serialisedData;
             }
         }
-        public String GetString(string key)
+        public string GetString(string key)
+
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));

--- a/src/Blazored.LocalStorage/LocalStorageService.cs
+++ b/src/Blazored.LocalStorage/LocalStorageService.cs
@@ -65,6 +65,14 @@ namespace Blazored.LocalStorage
             }
         }
 
+        public async Task<string> GetStringAsync(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentNullException(nameof(key));
+
+            return await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key);
+        }
+
         public async Task RemoveItemAsync(string key)
         {
             if (string.IsNullOrEmpty(key))
@@ -129,6 +137,16 @@ namespace Blazored.LocalStorage
             {
                 return (T)(object)serialisedData;
             }
+        }
+        public String GetString(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentNullException(nameof(key));
+
+            if (_jSInProcessRuntime == null)
+                throw new InvalidOperationException("IJSInProcessRuntime not available");
+
+            return _jSInProcessRuntime.Invoke<string>("localStorage.getItem", key);
         }
 
         public void RemoveItem(string key)
@@ -215,7 +233,7 @@ namespace Blazored.LocalStorage
             var e = new ChangingEventArgs
             {
                 Key = key,
-                OldValue = GetItemInternal<object>(key),
+                OldValue = GetItemInternal(key),
                 NewValue = data
             };
 
@@ -245,6 +263,38 @@ namespace Blazored.LocalStorage
             else
             {
                 return (T)(object)serialisedData;
+            }
+        }
+
+        public object GetItemInternal(string key)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentNullException(nameof(key));
+
+            if (_jSInProcessRuntime == null)
+                throw new InvalidOperationException("IJSInProcessRuntime not available");
+
+            var serialisedData = _jSInProcessRuntime.Invoke<string>("localStorage.getItem", key);
+
+            if (string.IsNullOrWhiteSpace(serialisedData))
+                return default;
+
+            if (serialisedData.StartsWith("{") && serialisedData.EndsWith("}")
+                || serialisedData.StartsWith("\"") && serialisedData.EndsWith("\""))
+            {
+                try
+                {
+                    //Try to deserialize
+                    return JsonSerializer.Deserialize<object>(serialisedData, _jsonOptions);
+                }
+                catch (JsonException)
+                {
+                    return serialisedData;
+                }
+            }
+            else
+            {
+                return serialisedData;
             }
         }
 


### PR DESCRIPTION
Implemented a **GetString** method, with directly returns the string saved in local storage without any attempt to parse it.
This can lead to errors in case the string is a custom serialization (like from using Newtonsoft, see #18 ) or a string which simply starts/ends with double quotes or curly braces but it's not a valid Json.

This issue is also demonstrated by the sample app: saving valid json won't appear below "Value Read from local storage" which yield to a blank resul, as the API tries to parse the string.
"String Read from local storage", added in this PR, correctly displays the json string.

Added a new non-generic **LocalStorageService.GetItemInternal**, and replaced its use inside RaiseOnChangingSync method which directly returns an object, if deserialization fails, it catches the *JsonException* and returns the string as stored.