### PR TITLE
Added ConfigureAwait(false) to support synchrounous execution

### DIFF
--- a/src/Blazored.LocalStorage/LocalStorageService.cs
+++ b/src/Blazored.LocalStorage/LocalStorageService.cs
@@ -25,19 +25,19 @@ namespace Blazored.LocalStorage
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
-            var e = await RaiseOnChangingAsync(key, data);
+            var e = await RaiseOnChangingAsync(key, data).ConfigureAwait(false);
 
             if (e.Cancel)
                 return;
 
             if (data is string)
             {
-                await _jSRuntime.InvokeVoidAsync("localStorage.setItem", key, data);
+                await _jSRuntime.InvokeVoidAsync("localStorage.setItem", key, data).ConfigureAwait(false);
             }
             else
             {
                 var serialisedData = JsonSerializer.Serialize(data, _jsonOptions);
-                await _jSRuntime.InvokeVoidAsync("localStorage.setItem", key, serialisedData);
+                await _jSRuntime.InvokeVoidAsync("localStorage.setItem", key, serialisedData).ConfigureAwait(false);
             }
 
             RaiseOnChanged(key, e.OldValue, data);
@@ -48,7 +48,7 @@ namespace Blazored.LocalStorage
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
-            var serialisedData = await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key);
+            var serialisedData = await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(serialisedData))
                 return default;
@@ -70,7 +70,7 @@ namespace Blazored.LocalStorage
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
-            return await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key);
+            return await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key).ConfigureAwait(false);
         }
 
         public async ValueTask RemoveItemAsync(string key)
@@ -78,16 +78,16 @@ namespace Blazored.LocalStorage
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
-            await _jSRuntime.InvokeVoidAsync("localStorage.removeItem", key);
+            await _jSRuntime.InvokeVoidAsync("localStorage.removeItem", key).ConfigureAwait(false);
         }
 
-        public async ValueTask ClearAsync() => await _jSRuntime.InvokeVoidAsync("localStorage.clear");
+        public async ValueTask ClearAsync() => await _jSRuntime.InvokeVoidAsync("localStorage.clear").ConfigureAwait(false);
 
-        public async ValueTask<int> LengthAsync() => await _jSRuntime.InvokeAsync<int>("eval", "localStorage.length");
+        public async ValueTask<int> LengthAsync() => await _jSRuntime.InvokeAsync<int>("eval", "localStorage.length").ConfigureAwait(false);
 
-        public async ValueTask<string> KeyAsync(int index) => await _jSRuntime.InvokeAsync<string>("localStorage.key", index);
+        public async ValueTask<string> KeyAsync(int index) => await _jSRuntime.InvokeAsync<string>("localStorage.key", index).ConfigureAwait(false);
 
-        public async ValueTask<bool> ContainKeyAsync(string key) => await _jSRuntime.InvokeAsync<bool>("localStorage.hasOwnProperty", key);
+        public async ValueTask<bool> ContainKeyAsync(string key) => await _jSRuntime.InvokeAsync<bool>("localStorage.hasOwnProperty", key).ConfigureAwait(false);
 
         public void SetItem<T>(string key, T data)
         {
@@ -199,7 +199,7 @@ namespace Blazored.LocalStorage
             var e = new ChangingEventArgs
             {
                 Key = key,
-                OldValue = await GetItemInternalAsync<object>(key),
+                OldValue = await GetItemInternalAsync<object>(key).ConfigureAwait(false),
                 NewValue = data
             };
 
@@ -227,7 +227,7 @@ namespace Blazored.LocalStorage
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));
 
-            var serialisedData = await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key);
+            var serialisedData = await _jSRuntime.InvokeAsync<string>("localStorage.getItem", key).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(serialisedData))
                 return default;


### PR DESCRIPTION
Is some particular use cases, users might encounter deadlocks while trying to invoke library code inside synchronous code (locks, etc).