### PR TITLE
Upgrade to .net6

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,7 +7,7 @@ on:
     types: [ published ]
 
 env:
-    NETCORE_VERSION: '5.0.400'
+    NETCORE_VERSION: '6.0.100-preview.6.21355.2'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     PROJECT_NAME: LocalStorage

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,7 +7,7 @@ on:
     types: [ published ]
 
 env:
-    NETCORE_VERSION: '6.0.100-preview.6.21355.2'
+    NETCORE_VERSION: '6.0.100-preview.7.21379.14'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     PROJECT_NAME: LocalStorage

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,7 +7,7 @@ on:
     types: [ published ]
 
 env:
-    NETCORE_VERSION: '6.0.100-preview.7.21379.14'
+    NETCORE_VERSION: '6.0.100'
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     PROJECT_NAME: LocalStorage

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-    NETCORE_VERSION: '6.0.100-preview.7.21379.14'
+    NETCORE_VERSION: '6.0.100'
     PROJECT_NAME: Blazored.LocalStorage
 
 jobs:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-    NETCORE_VERSION: '5.0.400'
+    NETCORE_VERSION: '6.0.100-preview.6.21355.2'
     PROJECT_NAME: Blazored.LocalStorage
 
 jobs:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-    NETCORE_VERSION: '6.0.100-preview.6.21355.2'
+    NETCORE_VERSION: '6.0.100-preview.7.21379.14'
     PROJECT_NAME: Blazored.LocalStorage
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100-preview.6.21355.2'
+        dotnet-version: '6.0.100-preview.7.21379.14'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100-preview.7.21379.14'
+        dotnet-version: '6.0.100'
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,6 +51,10 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.100-preview.6.21355.2'
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="Package Versions">
     <DotNet3Version>3.1.14</DotNet3Version>
     <DotNet5Version>5.0.5</DotNet5Version>
-    <DotNet6Version>6.0.0-preview.6.21355.2</DotNet6Version>
+    <DotNet6Version>6.0.0</DotNet6Version>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup Label="Package Versions">
     <DotNet3Version>3.1.14</DotNet3Version>
     <DotNet5Version>5.0.5</DotNet5Version>
+    <DotNet6Version>6.0.0-preview.6.21355.2</DotNet6Version>
   </PropertyGroup>
 
 </Project>

--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/BlazorWebAssembly/BlazorWebAssembly.csproj
+++ b/samples/BlazorWebAssembly/BlazorWebAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/bUnitExample/bUnitExample.csproj
+++ b/samples/bUnitExample/bUnitExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Blazored.LocalStorage.TestExtensions/Blazored.LocalStorage.TestExtensions.csproj
+++ b/src/Blazored.LocalStorage.TestExtensions/Blazored.LocalStorage.TestExtensions.csproj
@@ -50,4 +50,13 @@
     <None Include="..\Blazored.LocalStorage\Blazored.LocalStorage.snk" Link="Blazored.LocalStorage.snk" />
   </ItemGroup>
 
+   <!-- Microsoft.Extensions.Logging.Abstractions 6.0.0-preview.5.21301.5 introduced the analyzer which is not present
+       in .net5 or .netcore3.1 therefore we have to remove the analyzer otherwise the build will fail
+  -->
+  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Microsoft.Extensions.Logging.Generators'" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Blazored.LocalStorage.TestExtensions/Blazored.LocalStorage.TestExtensions.csproj
+++ b/src/Blazored.LocalStorage.TestExtensions/Blazored.LocalStorage.TestExtensions.csproj
@@ -53,7 +53,7 @@
    <!-- Microsoft.Extensions.Logging.Abstractions 6.0.0-preview.5.21301.5 introduced the analyzer which is not present
        in .net5 or .netcore3.1 therefore we have to remove the analyzer otherwise the build will fail
   -->
-  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile">
+  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile" Condition="'$(TargetFramework)' != 'net6.0'">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Microsoft.Extensions.Logging.Generators'" />
     </ItemGroup>

--- a/src/Blazored.LocalStorage.TestExtensions/Blazored.LocalStorage.TestExtensions.csproj
+++ b/src/Blazored.LocalStorage.TestExtensions/Blazored.LocalStorage.TestExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
 
     <Authors>Chris Sainty</Authors>
     <Company></Company>

--- a/src/Blazored.LocalStorage/Blazored.LocalStorage.csproj
+++ b/src/Blazored.LocalStorage/Blazored.LocalStorage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
 
     <Authors>Chris Sainty</Authors>
     <Company></Company>
@@ -30,7 +30,7 @@
     <RazorLangVersion>3.0</RazorLangVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
@@ -40,6 +40,10 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet5Version)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="$(DotNet6Version)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -61,5 +65,14 @@
       </_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
+
+  <!-- Microsoft.Extensions.Logging.Abstractions 6.0.0-preview.5.21301.5 introduced the analyzer which is not present
+       in .net5 or .netcore3.1 therefore we have to remove the analyzer otherwise the build will fail
+  -->
+  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Microsoft.Extensions.Logging.Generators'" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Blazored.LocalStorage/Blazored.LocalStorage.csproj
+++ b/src/Blazored.LocalStorage/Blazored.LocalStorage.csproj
@@ -69,7 +69,7 @@
   <!-- Microsoft.Extensions.Logging.Abstractions 6.0.0-preview.5.21301.5 introduced the analyzer which is not present
        in .net5 or .netcore3.1 therefore we have to remove the analyzer otherwise the build will fail
   -->
-  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile">
+  <Target Name="RemoveLoggingAnalyzer" BeforeTargets="CoreCompile" Condition="'$(TargetFramework)' != 'net6.0'">
     <ItemGroup>
       <Analyzer Remove="@(Analyzer)" Condition="%(FileName) == 'Microsoft.Extensions.Logging.Generators'" />
     </ItemGroup>

--- a/tests/Blazored.LocalStorage.Tests/Blazored.LocalStorage.Tests.csproj
+++ b/tests/Blazored.LocalStorage.Tests/Blazored.LocalStorage.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Essentially upgrade to .net6. Once .net6 is stable we only have to change the version in `Directory.Build.props`.

Resolves #148 