### PR TITLE
Expose synchronous methods on the ILocalStorageService interface.

### DIFF
--- a/src/Blazored.LocalStorage/ILocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ILocalStorageService.cs
@@ -13,6 +13,11 @@ namespace Blazored.LocalStorage
         ValueTask ClearAsync(CancellationToken? cancellationToken = null);
 
         /// <summary>
+        /// Clears all data from local storage.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
         /// Retrieve the specified data from local storage and deseralise it to the specfied type.
         /// </summary>
         /// <param name="key">A <see cref="string"/> value specifying the name of the local storage slot to use</param>
@@ -22,6 +27,16 @@ namespace Blazored.LocalStorage
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         ValueTask<T> GetItemAsync<T>(string key, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Retrieve the specified data from local storage and deseralise it to the specfied type.
+        /// </summary>
+        /// <param name="key">A <see cref="string"/> value specifying the name of the local storage slot to use</param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <returns>The item <see cref="T"/>.</returns>
+        T GetItem<T>(string key);
 
         /// <summary>
         /// Retrieve the specified data from local storage as a <see cref="string"/>.
@@ -35,6 +50,16 @@ namespace Blazored.LocalStorage
         ValueTask<string> GetItemAsStringAsync(string key, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        /// Retrieve the specified data from local storage as a <see cref="string"/>.
+        /// </summary>
+        /// <param name="key">A <see cref="string"/> value specifying the name of the storage slot to use</param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <returns>The item as a raw string value.</returns>
+        string GetItemAsString(string key);
+
+        /// <summary>
         /// Return the name of the key at the specified <paramref name="index"/>.
         /// </summary>
         /// <param name="index"></param>
@@ -44,6 +69,16 @@ namespace Blazored.LocalStorage
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         ValueTask<string> KeyAsync(int index, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Return the name of the key at the specified <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index"></param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <returns>The key at the index.</returns>
+        string Key(int index);
 
         /// <summary>
         /// Checks if the <paramref name="key"/> exists in local storage, but does not check its value.
@@ -57,10 +92,26 @@ namespace Blazored.LocalStorage
         ValueTask<bool> ContainKeyAsync(string key, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        /// Checks if the <paramref name="key"/> exists in local storage, but does not check its value.
+        /// </summary>
+        /// <param name="key">A <see cref="string"/> value specifying the name of the storage slot to use</param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        /// <returns>True/False if the storage has the key.</returns>
+        bool ContainKey(string key);
+
+        /// <summary>
         /// The number of items stored in local storage.
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         ValueTask<int> LengthAsync(CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// The number of items stored in local storage.
+        /// </summary>
+        /// <returns>The number of items in local storage.</returns>
+        int Length();
 
         /// <summary>
         /// Remove the data with the specified <paramref name="key"/>.
@@ -72,6 +123,15 @@ namespace Blazored.LocalStorage
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
         ValueTask RemoveItemAsync(string key, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Remove the data with the specified <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">A <see cref="string"/> value specifying the name of the storage slot to use</param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        void RemoveItem(string key);
 
         /// <summary>
         /// Sets or updates the <paramref name="data"/> in local storage with the specified <paramref name="key"/>.
@@ -86,6 +146,16 @@ namespace Blazored.LocalStorage
         ValueTask SetItemAsync<T>(string key, T data, CancellationToken? cancellationToken = null);
 
         /// <summary>
+        /// Sets or updates the <paramref name="data"/> in local storage with the specified <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">A <see cref="string"/> value specifying the name of the storage slot to use</param>
+        /// <param name="data">The data to be saved</param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        void SetItem<T>(string key, T data);
+
+        /// <summary>
         /// Sets or updates the <paramref name="data"/> in local storage with the specified <paramref name="key"/>. Does not serialize the value before storing.
         /// </summary>
         /// <param name="key">A <see cref="string"/> value specifying the name of the storage slot to use</param>
@@ -96,6 +166,16 @@ namespace Blazored.LocalStorage
         /// </param>
         /// <returns></returns>
         ValueTask SetItemAsStringAsync(string key, string data, CancellationToken? cancellationToken = null);
+
+        /// <summary>
+        /// Sets or updates the <paramref name="data"/> in local storage with the specified <paramref name="key"/>. Does not serialize the value before storing.
+        /// </summary>
+        /// <param name="key">A <see cref="string"/> value specifying the name of the storage slot to use</param>
+        /// <param name="data">The string to be saved</param>
+        /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
+        /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
+        /// </param>
+        void SetItemAsString(string key, string data);
 
         event EventHandler<ChangingEventArgs> Changing;
         event EventHandler<ChangedEventArgs> Changed;


### PR DESCRIPTION
I could not find a way to actually use this library from a blazor WASM project from class properties without the synchronous methods exposed.  I did not add any tests as it appears the concrete implementation of this interface already tests these methods.