### PR TITLE
Changed usage of CancellationToken

### DIFF
--- a/src/Blazored.LocalStorage.TestExtensions/InMemoryStorageProvider.cs
+++ b/src/Blazored.LocalStorage.TestExtensions/InMemoryStorageProvider.cs
@@ -12,7 +12,7 @@ namespace Blazored.LocalStorage.TestExtensions
         public void Clear()
             => _dataStore.Clear();
 
-        public ValueTask ClearAsync(CancellationToken? cancellationToken = null)
+        public ValueTask ClearAsync(CancellationToken cancellationToken = default)
         {
             _dataStore.Clear();
             return new ValueTask(Task.CompletedTask);
@@ -21,19 +21,19 @@ namespace Blazored.LocalStorage.TestExtensions
         public bool ContainKey(string key)
             => _dataStore.ContainsKey(key);
 
-        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken? cancellationToken = null)
+        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default)
             => new ValueTask<bool>(ContainKey(key));
 
-        public string GetItem(string key) 
+        public string GetItem(string key)
             => _dataStore.ContainsKey(key) ? _dataStore[key] : default;
 
-        public ValueTask<string> GetItemAsync(string key, CancellationToken? cancellationToken = null)
+        public ValueTask<string> GetItemAsync(string key, CancellationToken cancellationToken = default)
             => new ValueTask<string>(GetItem(key));
 
         public string Key(int index)
             => index > _dataStore.Count - 1 ? default : _dataStore.ElementAt(index).Key;
 
-        public ValueTask<string> KeyAsync(int index, CancellationToken? cancellationToken = null)
+        public ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default)
             => new ValueTask<string>(Key(index));
 
         public IEnumerable<string> Keys()
@@ -41,20 +41,20 @@ namespace Blazored.LocalStorage.TestExtensions
             return _dataStore.Keys.ToList();
         }
 
-        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken? cancellationToken = null)
+        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default)
             => new ValueTask<IEnumerable<string>>(_dataStore.Keys.ToList());
-        
+
 
         public int Length()
             => _dataStore.Count;
 
-        public ValueTask<int> LengthAsync(CancellationToken? cancellationToken = null)
+        public ValueTask<int> LengthAsync(CancellationToken cancellationToken = default)
             => new ValueTask<int>(Length());
 
         public void RemoveItem(string key)
             => _dataStore.Remove(key);
 
-        public ValueTask RemoveItemAsync(string key, CancellationToken? cancellationToken = null)
+        public ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default)
         {
             RemoveItem(key);
             return new ValueTask(Task.CompletedTask);
@@ -68,7 +68,7 @@ namespace Blazored.LocalStorage.TestExtensions
             }
         }
 
-        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken? cancellationToken = null)
+        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
         {
             RemoveItems(keys);
 
@@ -87,7 +87,7 @@ namespace Blazored.LocalStorage.TestExtensions
             }
         }
 
-        public ValueTask SetItemAsync(string key, string data, CancellationToken? cancellationToken = null)
+        public ValueTask SetItemAsync(string key, string data, CancellationToken cancellationToken = default)
         {
             SetItem(key, data);
             return new ValueTask(Task.CompletedTask);

--- a/src/Blazored.LocalStorage/BrowserStorageProvider.cs
+++ b/src/Blazored.LocalStorage/BrowserStorageProvider.cs
@@ -1,8 +1,8 @@
-using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
 namespace Blazored.LocalStorage
 {
@@ -17,37 +17,37 @@ namespace Blazored.LocalStorage
             _jSInProcessRuntime = jSRuntime as IJSInProcessRuntime;
         }
 
-        public ValueTask ClearAsync(CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeVoidAsync("localStorage.clear", cancellationToken ?? CancellationToken.None);
+        public ValueTask ClearAsync(CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeVoidAsync("localStorage.clear", cancellationToken);
 
-        public ValueTask<string> GetItemAsync(string key, CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeAsync<string>("localStorage.getItem", cancellationToken ?? CancellationToken.None, key);
+        public ValueTask<string> GetItemAsync(string key, CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeAsync<string>("localStorage.getItem", cancellationToken, key);
 
-        public ValueTask<string> KeyAsync(int index, CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeAsync<string>("localStorage.key", cancellationToken ?? CancellationToken.None, index);
+        public ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeAsync<string>("localStorage.key", cancellationToken, index);
 
-        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeAsync<bool>("localStorage.hasOwnProperty", cancellationToken ?? CancellationToken.None, key);
+        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeAsync<bool>("localStorage.hasOwnProperty", cancellationToken, key);
 
-        public ValueTask<int> LengthAsync(CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeAsync<int>("eval", cancellationToken ?? CancellationToken.None, "localStorage.length");
+        public ValueTask<int> LengthAsync(CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeAsync<int>("eval", cancellationToken, "localStorage.length");
 
-        public ValueTask RemoveItemAsync(string key, CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeVoidAsync("localStorage.removeItem", cancellationToken ?? CancellationToken.None, key);
+        public ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeVoidAsync("localStorage.removeItem", cancellationToken, key);
 
-        public ValueTask SetItemAsync(string key, string data, CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeVoidAsync("localStorage.setItem", cancellationToken ?? CancellationToken.None, key, data);
+        public ValueTask SetItemAsync(string key, string data, CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeVoidAsync("localStorage.setItem", cancellationToken, key, data);
 
-        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken? cancellationToken = null)
-            => _jSRuntime.InvokeAsync<IEnumerable<string>>("eval", cancellationToken ?? CancellationToken.None, "Object.keys(localStorage)");
+        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default)
+            => _jSRuntime.InvokeAsync<IEnumerable<string>>("eval", cancellationToken, "Object.keys(localStorage)");
 
-        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken? cancellationToken = null)
+        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
         {
             if (keys != null)
             {
                 foreach (var key in keys)
                 {
-                    _jSRuntime.InvokeVoidAsync("localStorage.removeItem", cancellationToken ?? CancellationToken.None, key);
+                    _jSRuntime.InvokeVoidAsync("localStorage.removeItem", cancellationToken, key);
                 }
             }
 

--- a/src/Blazored.LocalStorage/ILocalStorageService.cs
+++ b/src/Blazored.LocalStorage/ILocalStorageService.cs
@@ -11,7 +11,7 @@ namespace Blazored.LocalStorage
         /// Clears all data from local storage.
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask ClearAsync(CancellationToken? cancellationToken = null);
+        ValueTask ClearAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve the specified data from local storage and deseralise it to the specfied type.
@@ -22,7 +22,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask<T> GetItemAsync<T>(string key, CancellationToken? cancellationToken = null);
+        ValueTask<T> GetItemAsync<T>(string key, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Retrieve the specified data from local storage as a <see cref="string"/>.
@@ -33,7 +33,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask<string> GetItemAsStringAsync(string key, CancellationToken? cancellationToken = null);
+        ValueTask<string> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Return the name of the key at the specified <paramref name="index"/>.
@@ -44,7 +44,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask<string> KeyAsync(int index, CancellationToken? cancellationToken = null);
+        ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a collection of strings representing the names of the keys in the local storage.
@@ -54,7 +54,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask<IEnumerable<string>> KeysAsync(CancellationToken? cancellationToken = null);
+        ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Checks if the <paramref name="key"/> exists in local storage, but does not check its value.
@@ -65,13 +65,13 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask<bool> ContainKeyAsync(string key, CancellationToken? cancellationToken = null);
+        ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// The number of items stored in local storage.
         /// </summary>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask<int> LengthAsync(CancellationToken? cancellationToken = null);
+        ValueTask<int> LengthAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Remove the data with the specified <paramref name="key"/>.
@@ -82,7 +82,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask RemoveItemAsync(string key, CancellationToken? cancellationToken = null);
+        ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Removes a collection of <paramref name="keys"/>.
@@ -92,7 +92,7 @@ namespace Blazored.LocalStorage
         /// A cancellation token to signal the cancellation of the operation. Specifying this parameter will override any default cancellations such as due to timeouts
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
-        ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken? cancellationToken = null);
+        ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sets or updates the <paramref name="data"/> in local storage with the specified <paramref name="key"/>.
@@ -104,7 +104,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns>A <see cref="ValueTask"/> representing the completion of the operation.</returns>
-        ValueTask SetItemAsync<T>(string key, T data, CancellationToken? cancellationToken = null);
+        ValueTask SetItemAsync<T>(string key, T data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Sets or updates the <paramref name="data"/> in local storage with the specified <paramref name="key"/>. Does not serialize the value before storing.
@@ -116,7 +116,7 @@ namespace Blazored.LocalStorage
         /// (<see cref="JSRuntime.DefaultAsyncTimeout"/>) from being applied.
         /// </param>
         /// <returns></returns>
-        ValueTask SetItemAsStringAsync(string key, string data, CancellationToken? cancellationToken = null);
+        ValueTask SetItemAsStringAsync(string key, string data, CancellationToken cancellationToken = default);
 
         event EventHandler<ChangingEventArgs> Changing;
         event EventHandler<ChangedEventArgs> Changed;

--- a/src/Blazored.LocalStorage/IStorageProvider.cs
+++ b/src/Blazored.LocalStorage/IStorageProvider.cs
@@ -7,23 +7,23 @@ namespace Blazored.LocalStorage
     internal interface IStorageProvider
     {
         void Clear();
-        ValueTask ClearAsync(CancellationToken? cancellationToken = null);
+        ValueTask ClearAsync(CancellationToken cancellationToken = default);
         bool ContainKey(string key);
-        ValueTask<bool> ContainKeyAsync(string key, CancellationToken? cancellationToken = null);
+        ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default);
         string GetItem(string key);
-        ValueTask<string> GetItemAsync(string key, CancellationToken? cancellationToken = null);
+        ValueTask<string> GetItemAsync(string key, CancellationToken cancellationToken = default);
         string Key(int index);
-        ValueTask<string> KeyAsync(int index, CancellationToken? cancellationToken = null);
+        ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default);
         IEnumerable<string> Keys();
-        ValueTask<IEnumerable<string>> KeysAsync(CancellationToken? cancellationToken = null);
+        ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default);
         int Length();
-        ValueTask<int> LengthAsync(CancellationToken? cancellationToken = null);
+        ValueTask<int> LengthAsync(CancellationToken cancellationToken = default);
         void RemoveItem(string key);
-        ValueTask RemoveItemAsync(string key, CancellationToken? cancellationToken = null);
+        ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default);
         void RemoveItems(IEnumerable<string> keys);
-        ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken? cancellationToken = null);
+        ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default);
         void SetItem(string key, string data);
-        ValueTask SetItemAsync(string key, string data, CancellationToken? cancellationToken = null);
+        ValueTask SetItemAsync(string key, string data, CancellationToken cancellationToken = default);
 
     }
 }

--- a/src/Blazored.LocalStorage/LocalStorageService.cs
+++ b/src/Blazored.LocalStorage/LocalStorageService.cs
@@ -18,7 +18,7 @@ namespace Blazored.LocalStorage
             _serializer = serializer;
         }
 
-        public async ValueTask SetItemAsync<T>(string key, T data, CancellationToken? cancellationToken = null)
+        public async ValueTask SetItemAsync<T>(string key, T data, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
@@ -34,7 +34,7 @@ namespace Blazored.LocalStorage
             RaiseOnChanged(key, e.OldValue, data);
         }
 
-        public async ValueTask SetItemAsStringAsync(string key, string data, CancellationToken? cancellationToken = null)
+        public async ValueTask SetItemAsStringAsync(string key, string data, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
@@ -52,7 +52,7 @@ namespace Blazored.LocalStorage
             RaiseOnChanged(key, e.OldValue, data);
         }
 
-        public async ValueTask<T> GetItemAsync<T>(string key, CancellationToken? cancellationToken = null)
+        public async ValueTask<T> GetItemAsync<T>(string key, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
@@ -74,7 +74,7 @@ namespace Blazored.LocalStorage
             }
         }
 
-        public ValueTask<string> GetItemAsStringAsync(string key, CancellationToken? cancellationToken = null)
+        public ValueTask<string> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
@@ -82,7 +82,7 @@ namespace Blazored.LocalStorage
             return _storageProvider.GetItemAsync(key, cancellationToken);
         }
 
-        public ValueTask RemoveItemAsync(string key, CancellationToken? cancellationToken = null)
+        public ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))
                 throw new ArgumentNullException(nameof(key));
@@ -90,27 +90,27 @@ namespace Blazored.LocalStorage
             return _storageProvider.RemoveItemAsync(key, cancellationToken);
         }
 
-        public ValueTask ClearAsync(CancellationToken? cancellationToken = null)
+        public ValueTask ClearAsync(CancellationToken cancellationToken = default)
             => _storageProvider.ClearAsync(cancellationToken);
 
-        public ValueTask<int> LengthAsync(CancellationToken? cancellationToken = null)
+        public ValueTask<int> LengthAsync(CancellationToken cancellationToken = default)
             => _storageProvider.LengthAsync(cancellationToken);
 
-        public ValueTask<string> KeyAsync(int index, CancellationToken? cancellationToken = null)
+        public ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default)
             => _storageProvider.KeyAsync(index, cancellationToken);
 
-        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken? cancellationToken = null)
+        public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default)
             => _storageProvider.KeysAsync(cancellationToken);
 
-        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken? cancellationToken = null)
+        public ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default)
             => _storageProvider.ContainKeyAsync(key, cancellationToken);
 
-        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken? cancellationToken = null)
+        public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
             => _storageProvider.RemoveItemsAsync(keys, cancellationToken);
 
         public IEnumerable<string> Keys()
         {
-           return _storageProvider.Keys();
+            return _storageProvider.Keys();
         }
 
         public void SetItem<T>(string key, T data)
@@ -237,7 +237,7 @@ namespace Blazored.LocalStorage
             return e;
         }
 
-        private async Task<T> GetItemInternalAsync<T>(string key, CancellationToken? cancellationToken = null)
+        private async Task<T> GetItemInternalAsync<T>(string key, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentNullException(nameof(key));


### PR DESCRIPTION
We can use  
`CancellationToken cancellationToken = default`  
instead of  
`CancellationToken? cancellationToken = null` and `cancellationToken ?? CancellationToken.None`

```cs
using System.Diagnostics;
using System.Threading;
```

```cs
CancellationToken cancellationToken = default;
Debug.Assert(cancellationToken == CancellationToken.None);
```

```cs
CancellationToken? cancellationToken = null;
cancellationToken = CancellationToken.None;
Debug.Assert(cancellationToken == CancellationToken.None);
```

![image](https://user-images.githubusercontent.com/4335913/174733041-0dcbcf78-310e-4d04-8ced-546b5255ac0d.png)
