### PR TITLE
return specific default value

### DIFF
--- a/src/Blazored.LocalStorage/LocalStorageService.cs
+++ b/src/Blazored.LocalStorage/LocalStorageService.cs
@@ -74,6 +74,19 @@ namespace Blazored.LocalStorage
             }
         }
 
+        public async ValueTask<T> GetItemAsync<T>(string key, T defaultValue, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException(nameof(key));
+
+            bool containsKey = await ContainKeyAsync(key, cancellationToken);
+            if (containsKey)
+            {
+                return await GetItemAsync<T>(key, cancellationToken);
+            }
+            return defaultValue;
+        }
+
         public ValueTask<string> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(key))

--- a/tests/Blazored.LocalStorage.Tests/LocalStorageServiceTests/GetItemAsync.cs
+++ b/tests/Blazored.LocalStorage.Tests/LocalStorageServiceTests/GetItemAsync.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Blazored.LocalStorage.JsonConverters;
@@ -101,6 +101,28 @@ namespace Blazored.LocalStorage.Tests.LocalStorageServiceTests
 
             // Assert
             Assert.Equal(valueToSave, result);
+        }
+
+        [Fact]
+        public async Task ReturnsDefaultBooleanValue_When_KeyNotExists()
+        {
+            // Arrange / Act
+
+            var result = await _sut.GetItemAsync<bool>("NonExistentKey");
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ReturnsSpecificDefaultBooleanValue_When_KeyNotExists()
+        {
+            // Arrange / Act
+
+            var result = await _sut.GetItemAsync<bool>("NonExistentKey", defaultValue: true);
+
+            // Assert
+            Assert.True(result);
         }
     }
 }


### PR DESCRIPTION
If a key doesn't exist, I need to get a defined return value that's different from the datatype's default. E.g. `GetItemAsync<bool>("NonExistingKey")` returns false by default, but in a special case I need true as return value. This is now possible with the call of `GetItemAsync<bool>("NonEyistingKey", defaultValue: true)`.