### PR TITLE
Service duplication fix

### DIFF
--- a/src/Blazored.LocalStorage/ServiceCollectionExtensions.cs
+++ b/src/Blazored.LocalStorage/ServiceCollectionExtensions.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Blazored.LocalStorage.JsonConverters;
 using Blazored.LocalStorage.Serialization;
 using Blazored.LocalStorage.StorageOptions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Blazored.LocalStorage
 {
@@ -15,18 +16,18 @@ namespace Blazored.LocalStorage
 
         public static IServiceCollection AddBlazoredLocalStorage(this IServiceCollection services, Action<LocalStorageOptions> configure)
         {
-            return services
-                .AddScoped<IJsonSerializer, SystemTextJsonSerializer>()
-                .AddScoped<IStorageProvider, BrowserStorageProvider>()
-                .AddScoped<ILocalStorageService, LocalStorageService>()
-                .AddScoped<ISyncLocalStorageService, LocalStorageService>()
-                .Configure<LocalStorageOptions>(configureOptions =>
-                {
-                    configure?.Invoke(configureOptions);
-                    configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
-                });
+            services.TryAddScoped<IJsonSerializer, SystemTextJsonSerializer>();
+            services.TryAddScoped<IStorageProvider, BrowserStorageProvider>();
+            services.TryAddScoped<ILocalStorageService, LocalStorageService>();
+            services.TryAddScoped<ISyncLocalStorageService, LocalStorageService>();
+            services.Configure<LocalStorageOptions>(configureOptions =>
+            {
+                configure?.Invoke(configureOptions);
+                configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
+            });
+            return services;
         }
-        
+
         /// <summary>
         /// Registers the Blazored LocalStorage services as singletons. This should only be used in Blazor WebAssembly applications.
         /// Using this in Blazor Server applications will cause unexpected and potentially dangerous behaviour. 
@@ -34,7 +35,7 @@ namespace Blazored.LocalStorage
         /// <returns></returns>
         public static IServiceCollection AddBlazoredLocalStorageAsSingleton(this IServiceCollection services)
             => AddBlazoredLocalStorageAsSingleton(services, null);
-        
+
         /// <summary>
         /// Registers the Blazored LocalStorage services as singletons. This should only be used in Blazor WebAssembly applications.
         /// Using this in Blazor Server applications will cause unexpected and potentially dangerous behaviour. 
@@ -44,16 +45,16 @@ namespace Blazored.LocalStorage
         /// <returns></returns>
         public static IServiceCollection AddBlazoredLocalStorageAsSingleton(this IServiceCollection services, Action<LocalStorageOptions> configure)
         {
-            return services
-                .AddSingleton<IJsonSerializer, SystemTextJsonSerializer>()
-                .AddSingleton<IStorageProvider, BrowserStorageProvider>()
-                .AddSingleton<ILocalStorageService, LocalStorageService>()
-                .AddSingleton<ISyncLocalStorageService, LocalStorageService>()
-                .Configure<LocalStorageOptions>(configureOptions =>
-                {
-                    configure?.Invoke(configureOptions);
-                    configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
-                });
+            services.TryAddSingleton<IJsonSerializer, SystemTextJsonSerializer>();
+            services.TryAddSingleton<IStorageProvider, BrowserStorageProvider>();
+            services.TryAddSingleton<ILocalStorageService, LocalStorageService>();
+            services.TryAddSingleton<ISyncLocalStorageService, LocalStorageService>();
+            services.Configure<LocalStorageOptions>(configureOptions =>
+            {
+                configure?.Invoke(configureOptions);
+                configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
+            });
+            return services;
         }
     }
 }

--- a/src/Blazored.LocalStorage/ServiceCollectionExtensions.cs
+++ b/src/Blazored.LocalStorage/ServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Blazored.LocalStorage.JsonConverters;
 using Blazored.LocalStorage.Serialization;
 using Blazored.LocalStorage.StorageOptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Blazored.LocalStorage
 {
@@ -20,11 +22,15 @@ namespace Blazored.LocalStorage
             services.TryAddScoped<IStorageProvider, BrowserStorageProvider>();
             services.TryAddScoped<ILocalStorageService, LocalStorageService>();
             services.TryAddScoped<ISyncLocalStorageService, LocalStorageService>();
-            services.Configure<LocalStorageOptions>(configureOptions =>
+            if (services.All(serviceDescriptor => serviceDescriptor.ServiceType != typeof(IConfigureOptions<LocalStorageOptions>)))
             {
-                configure?.Invoke(configureOptions);
-                configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
-            });
+                services.Configure<LocalStorageOptions>(configureOptions =>
+                {
+                    configure?.Invoke(configureOptions);
+                    configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
+                });
+            }
+
             return services;
         }
 
@@ -49,11 +55,14 @@ namespace Blazored.LocalStorage
             services.TryAddSingleton<IStorageProvider, BrowserStorageProvider>();
             services.TryAddSingleton<ILocalStorageService, LocalStorageService>();
             services.TryAddSingleton<ISyncLocalStorageService, LocalStorageService>();
-            services.Configure<LocalStorageOptions>(configureOptions =>
+            if (services.All(serviceDescriptor => serviceDescriptor.ServiceType != typeof(IConfigureOptions<LocalStorageOptions>)))
             {
-                configure?.Invoke(configureOptions);
-                configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
-            });
+                services.Configure<LocalStorageOptions>(configureOptions =>
+                {
+                    configure?.Invoke(configureOptions);
+                    configureOptions.JsonSerializerOptions.Converters.Add(new TimespanJsonConverter());
+                });
+            }
             return services;
         }
     }

--- a/tests/Blazored.LocalStorage.Tests/LocalStorageServiceTests/ServiceCollectionExtensionsTest.cs
+++ b/tests/Blazored.LocalStorage.Tests/LocalStorageServiceTests/ServiceCollectionExtensionsTest.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using Blazored.LocalStorage.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Blazored.LocalStorage.Tests.LocalStorageServiceTests;
+
+public class ServiceCollectionExtensionsTest
+{
+    [Fact]
+    public void Scoped()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddBlazoredLocalStorage();
+        services.AddBlazoredLocalStorage();
+        services.AddBlazoredLocalStorage();
+        services.AddBlazoredLocalStorage();
+
+        // Assert
+        AssertEqual(services, typeof(IJsonSerializer), typeof(SystemTextJsonSerializer), ServiceLifetime.Scoped);
+        AssertEqual(services, typeof(IStorageProvider), typeof(BrowserStorageProvider), ServiceLifetime.Scoped);
+        AssertEqual(services, typeof(ILocalStorageService), typeof(LocalStorageService), ServiceLifetime.Scoped);
+        AssertEqual(services, typeof(ISyncLocalStorageService), typeof(LocalStorageService), ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void Singleton()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddBlazoredLocalStorageAsSingleton();
+        services.AddBlazoredLocalStorageAsSingleton();
+        services.AddBlazoredLocalStorageAsSingleton();
+        services.AddBlazoredLocalStorageAsSingleton();
+
+        // Assert
+        AssertEqual(services, typeof(IJsonSerializer), typeof(SystemTextJsonSerializer), ServiceLifetime.Singleton);
+        AssertEqual(services, typeof(IStorageProvider), typeof(BrowserStorageProvider), ServiceLifetime.Singleton);
+        AssertEqual(services, typeof(ILocalStorageService), typeof(LocalStorageService), ServiceLifetime.Singleton);
+        AssertEqual(services, typeof(ISyncLocalStorageService), typeof(LocalStorageService), ServiceLifetime.Singleton);
+    }
+
+
+    static void AssertEqual(
+        IServiceCollection services,
+        Type serviceType,
+        Type implementationType,
+        ServiceLifetime serviceLifetime
+        )
+    {
+        var descriptors = services.Where(serviceDescriptor => serviceDescriptor.ServiceType == serviceType).ToArray();
+        Assert.Single(descriptors);
+        var descriptor = descriptors.Single();
+        Assert.Equal(serviceType, descriptor.ServiceType);
+        Assert.Equal(implementationType, descriptor.ImplementationType);
+        Assert.Equal(serviceLifetime, descriptor.Lifetime);
+    }
+}

--- a/tests/Blazored.LocalStorage.Tests/LocalStorageServiceTests/ServiceCollectionExtensionsTest.cs
+++ b/tests/Blazored.LocalStorage.Tests/LocalStorageServiceTests/ServiceCollectionExtensionsTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
 using Blazored.LocalStorage.Serialization;
+using Blazored.LocalStorage.StorageOptions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Blazored.LocalStorage.Tests.LocalStorageServiceTests;
@@ -25,6 +27,7 @@ public class ServiceCollectionExtensionsTest
         AssertEqual(services, typeof(IStorageProvider), typeof(BrowserStorageProvider), ServiceLifetime.Scoped);
         AssertEqual(services, typeof(ILocalStorageService), typeof(LocalStorageService), ServiceLifetime.Scoped);
         AssertEqual(services, typeof(ISyncLocalStorageService), typeof(LocalStorageService), ServiceLifetime.Scoped);
+        AssertEqualConfigureOptions(services, typeof(IConfigureOptions<LocalStorageOptions>), ServiceLifetime.Singleton);
     }
 
     [Fact]
@@ -44,6 +47,7 @@ public class ServiceCollectionExtensionsTest
         AssertEqual(services, typeof(IStorageProvider), typeof(BrowserStorageProvider), ServiceLifetime.Singleton);
         AssertEqual(services, typeof(ILocalStorageService), typeof(LocalStorageService), ServiceLifetime.Singleton);
         AssertEqual(services, typeof(ISyncLocalStorageService), typeof(LocalStorageService), ServiceLifetime.Singleton);
+        AssertEqualConfigureOptions(services, typeof(IConfigureOptions<LocalStorageOptions>), ServiceLifetime.Singleton);
     }
 
 
@@ -59,6 +63,19 @@ public class ServiceCollectionExtensionsTest
         var descriptor = descriptors.Single();
         Assert.Equal(serviceType, descriptor.ServiceType);
         Assert.Equal(implementationType, descriptor.ImplementationType);
+        Assert.Equal(serviceLifetime, descriptor.Lifetime);
+    }
+
+    static void AssertEqualConfigureOptions(
+        IServiceCollection services,
+        Type serviceType,
+        ServiceLifetime serviceLifetime
+    )
+    {
+        var descriptors = services.Where(serviceDescriptor => serviceDescriptor.ServiceType == serviceType).ToArray();
+        Assert.Single(descriptors);
+        var descriptor = descriptors.Single();
+        Assert.Equal(serviceType, descriptor.ServiceType);
         Assert.Equal(serviceLifetime, descriptor.Lifetime);
     }
 }


### PR DESCRIPTION
Fixes when multiple nuget packages or project references contain Blazored.LocalStorage and call AddBlazoredLocalStorage() No error occurs if it is added more than once, but the services are only needed once.